### PR TITLE
Improve BeatmapSuggest&NowPlaying

### DIFF
--- a/BeatmapSuggest/BeatmapDownloadScheduler.cs
+++ b/BeatmapSuggest/BeatmapDownloadScheduler.cs
@@ -63,7 +63,7 @@ namespace BeatmapSuggest
             BeatmapDownloadTask map = suggest_history_queue.Last();
             suggest_history_queue.RemoveLast();
 
-            SendIRCMessage($"开始下载谱面{map.name}");
+            SendIRCMessage(string.Format(DefaultLanguage.LANG_START_DOWNLOAD,map.name));
 
             DownloadBeatmap(map);
         }
@@ -76,7 +76,7 @@ namespace BeatmapSuggest
             var copy_list = new LinkedList<BeatmapDownloadTask>(suggest_history_queue);
             suggest_history_queue.Clear();
 
-            SendIRCMessage($"开始下载共{copy_list.Count}张谱面.");
+            SendIRCMessage(string.Format(DefaultLanguage.LANG_DOWNLOAD_TASK_COUNT,copy_list.Count));
 
             foreach (var map in copy_list)
             {
@@ -142,18 +142,18 @@ namespace BeatmapSuggest
                         }
                     }
 
-                    IO.CurrentIO.WriteColor($"开始下载谱面{map.name}", ConsoleColor.Green);
+                    IO.CurrentIO.WriteColor(string.Format(DefaultLanguage.LANG_START_DOWNLOAD, map.name), ConsoleColor.Green);
 
                     string download_url = $"http://osu.uu.gl/s/{beatmap_setid}";
 
                     WebClient wc = new WebClient();
                     wc.DownloadFile(new Uri(download_url), save_path + "\\" + $"{beatmap_setid}.osz");
 
-                    IO.CurrentIO.WriteColor($"下载谱面{map.name}完成", ConsoleColor.Green);
+                    IO.CurrentIO.WriteColor(string.Format(DefaultLanguage.LANG_FINISH_DOWNLOAD, map.name), ConsoleColor.Green);
                 }
                 catch (Exception e)
                 {
-                    IO.CurrentIO.WriteColor($"下载谱面{map.name}出错,原因{e.Message}", ConsoleColor.Red);
+                    IO.CurrentIO.WriteColor(string.Format(DefaultLanguage.LANG_FAILED_DOWNLOAD, map.name,e.Message), ConsoleColor.Red);
                 }
             });
         }

--- a/BeatmapSuggest/BeatmapDownloadScheduler.cs
+++ b/BeatmapSuggest/BeatmapDownloadScheduler.cs
@@ -1,0 +1,170 @@
+﻿using Sync.Tools;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace BeatmapSuggest
+{
+    public struct BeatmapDownloadTask
+    {
+        public int id;
+        public bool isSetId;
+        public string name;
+    }
+
+    public class BeatmapDownloadScheduler
+    {
+        private LinkedList<BeatmapDownloadTask> suggest_history_queue;
+        
+        string save_path;
+
+        string api_key;
+
+        int capacity;
+
+        public BeatmapDownloadScheduler(int history_capacity,string api_key)
+        {
+            suggest_history_queue = new LinkedList<BeatmapDownloadTask>();
+            capacity = history_capacity;
+            this.api_key = api_key;
+        }
+
+        public void Push(int id,bool isSetId,string name)
+        {
+            if (capacity<suggest_history_queue.Count)
+            {
+                suggest_history_queue.RemoveFirst();
+            }
+
+            BeatmapDownloadTask task = new BeatmapDownloadTask()
+            {
+                id=id,
+                isSetId=isSetId,
+                name=name
+            };
+
+            suggest_history_queue.AddLast(task);
+
+            IO.CurrentIO.Write($"[BeatmapSuggest]Push {name}");
+        }
+
+        public void DownloadLastSuggest()
+        {
+            BeatmapDownloadTask map = suggest_history_queue.Last();
+            suggest_history_queue.RemoveLast();
+            DownloadBeatmap(map);
+        }
+
+        public void DownloadAll()
+        {
+            var copy_list = new LinkedList<BeatmapDownloadTask>(suggest_history_queue);
+            suggest_history_queue.Clear();
+
+            foreach (var map in copy_list)
+            {
+                DownloadBeatmap(map);
+            }
+        }
+
+        private bool TryGetOsuSongFolder()
+        {
+            if (string.IsNullOrWhiteSpace(save_path))
+            {
+                var processes = Process.GetProcessesByName(@"osu!");
+                if (processes.Length != 0)
+                {
+                    string osu_path = processes[0].MainModule.FileName.Replace(@"osu!.exe", string.Empty);
+
+                    string osu_config_file = Path.Combine(osu_path, $"osu!.{Environment.UserName}.cfg");
+                    var lines = File.ReadLines(osu_config_file);
+                    string song_path;
+                    foreach (var line in lines)
+                    {
+                        if (line.StartsWith("BeatmapDirectory"))
+                        {
+                            song_path = line.Split('=')[1].Trim();
+                            if (Path.IsPathRooted(song_path))
+                                save_path = song_path;
+                            else
+                                save_path = Path.Combine(osu_path, song_path);
+                            break;
+                        }
+                    }
+                    return true;
+                }
+                else
+                {
+                    //not found
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private async void DownloadBeatmap(BeatmapDownloadTask map)
+        {
+            await Task.Run(() => 
+            {
+                try
+                {
+                    if (!TryGetOsuSongFolder())
+                    {
+                        return;
+                    }
+
+                    int beatmap_setid=map.id;
+
+                    if (!map.isSetId)
+                    {
+                        beatmap_setid = GetBeatmapSetID(map.id);
+                        if (beatmap_setid<0)
+                        {
+                            return;
+                        }
+                    }
+
+                    IO.CurrentIO.WriteColor($"开始下载谱面{map.id}", ConsoleColor.Green);
+
+                    string download_url = $"http://osu.uu.gl/s/{beatmap_setid}";
+
+                    WebClient wc = new WebClient();
+                    wc.DownloadFile(new Uri(download_url), save_path + "\\" + $"{beatmap_setid}.osz");
+                    
+                    IO.CurrentIO.WriteColor($"下载谱面{map.id}完成", ConsoleColor.Green);
+                }
+                catch (Exception e)
+                {
+                    IO.CurrentIO.WriteColor($"下载谱面{map.id}出错,原因{e.Message}", ConsoleColor.Red);
+                }
+            });
+        }
+
+        private int GetBeatmapSetID(int id)
+        {
+            string uri = @"https://osu.ppy.sh/api/get_beatmaps?" +
+                $@"k={api_key}&b={id}&limit=1";
+
+            HttpWebRequest request = HttpWebRequest.Create(uri) as HttpWebRequest;
+            request.Method = "GET";
+            var response = (HttpWebResponse)request.GetResponse();
+            var stream = new StreamReader(response.GetResponseStream(), Encoding.UTF8);
+            string data = stream.ReadToEnd();
+
+            stream.Close();
+
+            var result = Regex.Match(data, $"\"beatmapset_id\":\"(.+?)\"");
+
+            if (!result.Success)
+                return -1;
+
+            return int.Parse(result.Groups[1].Value);
+        }
+    }
+}

--- a/BeatmapSuggest/BeatmapDownloadScheduler.cs
+++ b/BeatmapSuggest/BeatmapDownloadScheduler.cs
@@ -84,6 +84,10 @@ namespace BeatmapSuggest
             }
         }
 
+        /// <summary>
+        /// 试图获取当前Songs文件夹路径
+        /// </summary>
+        /// <returns></returns>
         private bool TryGetOsuSongFolder()
         {
             if (string.IsNullOrWhiteSpace(save_path))
@@ -105,16 +109,12 @@ namespace BeatmapSuggest
                                 save_path = song_path;
                             else
                                 save_path = Path.Combine(osu_path, song_path);
-                            break;
+                            return true;
                         }
                     }
-                    return true;
                 }
-                else
-                {
-                    //not found
-                    return false;
-                }
+
+                return false;
             }
 
             return true;
@@ -133,6 +133,7 @@ namespace BeatmapSuggest
 
                     int beatmap_setid=map.id;
 
+                    //通过id获取对应的setid
                     if (!map.isSetId)
                     {
                         beatmap_setid = GetBeatmapSetID(map.id);
@@ -143,7 +144,7 @@ namespace BeatmapSuggest
                     }
 
                     IO.CurrentIO.WriteColor(string.Format(DefaultLanguage.LANG_START_DOWNLOAD, map.name), ConsoleColor.Green);
-
+                    
                     string download_url = $"http://osu.uu.gl/s/{beatmap_setid}";
 
                     WebClient wc = new WebClient();
@@ -158,6 +159,11 @@ namespace BeatmapSuggest
             });
         }
 
+        /// <summary>
+        /// 借助osu api,获取beatmapID对应的BeatmapSetID
+        /// </summary>
+        /// <param name="id">beatmapID</param>
+        /// <returns></returns>
         private int GetBeatmapSetID(int id)
         {
             string uri = @"https://osu.ppy.sh/api/get_beatmaps?" +

--- a/BeatmapSuggest/BeatmapSuggest.csproj
+++ b/BeatmapSuggest/BeatmapSuggest.csproj
@@ -47,9 +47,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BeatmapDownloadScheduler.cs" />
     <Compile Include="BeatmapSuggestPlugin.cs" />
     <Compile Include="Danmaku\BeatmapSuggestFilter.cs" />
     <Compile Include="DefaultLanguage.cs" />
+    <Compile Include="Osu\BeatmapSuggestDownloadFilter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -59,6 +61,7 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/BeatmapSuggest/BeatmapSuggestPlugin.cs
+++ b/BeatmapSuggest/BeatmapSuggestPlugin.cs
@@ -25,6 +25,8 @@ namespace BeatmapSuggest
 
         public BeatmapSuggestPlugin() : base("Beatmap Suggest Command", "Dark Projector")
         {
+            I18n.Instance.ApplyLanguage(new DefaultLanguage());
+
             danmaku_filter = new Danmaku.BeatmapSuggestFilter();
             osu_filter = new Osu.BeatmapSuggestDownloadFilter();
 
@@ -49,7 +51,7 @@ namespace BeatmapSuggest
         {
             if (string.IsNullOrWhiteSpace(OsuApiKey))
             {
-                IO.CurrentIO.WriteColor("[BeatmapSuggestPlugin]没有ApiKey,请用户自己提供ApiKey以便使用谱面推荐功能.ApiKey申请地址:https://osu.ppy.sh/p/api", ConsoleColor.Red);
+                IO.CurrentIO.WriteColor("[BeatmapSuggestPlugin]"+DefaultLanguage.LANG_NO_API_KEY_NOFITY, ConsoleColor.Red);
                 return;
             }
 

--- a/BeatmapSuggest/BeatmapSuggestPlugin.cs
+++ b/BeatmapSuggest/BeatmapSuggestPlugin.cs
@@ -12,30 +12,69 @@ using Sync.Tools;
 namespace BeatmapSuggest
 {
     [SyncPluginID("916fe745-7a33-4c20-b985-58c4810e261e", "2.15.0")]
-    public class BeatmapSuggestPlugin : Plugin
+    public class BeatmapSuggestPlugin : Plugin,IConfigurable
     {
-        private Danmaku.BeatmapSuggestFilter filter;
+        public ConfigurationElement EnableInsoMirrorLink { get; set; } = "False";
+        public ConfigurationElement OsuApiKey { get; set; } = string.Empty;
+        public ConfigurationElement SuggestHistoryCapacity { get; set; } = "10";
+
+        private Danmaku.BeatmapSuggestFilter danmaku_filter;
+        private Osu.BeatmapSuggestDownloadFilter osu_filter;
 
         private PluginConfigurationManager config_manager;
 
         public BeatmapSuggestPlugin() : base("Beatmap Suggest Command", "Dark Projector")
         {
-            filter = new Danmaku.BeatmapSuggestFilter();
+            danmaku_filter = new Danmaku.BeatmapSuggestFilter();
+            osu_filter = new Osu.BeatmapSuggestDownloadFilter();
 
-            base.EventBus.BindEvent<PluginEvents.InitFilterEvent>(manager => manager.Filters.AddFilter(this.filter));
-            base.EventBus.BindEvent<PluginEvents.LoadCompleteEvent>(host => this.filter.SetFilterManager(host.Host.Messages));
+            base.EventBus.BindEvent<PluginEvents.InitFilterEvent>(manager => {
+                manager.Filters.AddFilter(this.danmaku_filter);
+                manager.Filters.AddFilter(this.osu_filter);
+            });
+
+            base.EventBus.BindEvent<PluginEvents.LoadCompleteEvent>(host => this.danmaku_filter.SetFilterManager(host.Host.Messages));
             Sync.Tools.IO.CurrentIO.WriteColor(Name + " By " + Author, ConsoleColor.DarkCyan);
 
             config_manager = new PluginConfigurationManager(this);
-            config_manager.AddItem(filter);
+            config_manager.AddItem(this);
         }
 
         public override void OnEnable()
         {
-            if (string.IsNullOrWhiteSpace(filter.OsuApiKey))
+            InitPlugin();
+        }
+
+        private void InitPlugin()
+        {
+            if (string.IsNullOrWhiteSpace(OsuApiKey))
             {
                 IO.CurrentIO.WriteColor("[BeatmapSuggestPlugin]没有ApiKey,请用户自己提供ApiKey以便使用谱面推荐功能.ApiKey申请地址:https://osu.ppy.sh/p/api", ConsoleColor.Red);
+                return;
             }
+
+            BeatmapDownloadScheduler scheduler = new BeatmapDownloadScheduler(int.Parse(SuggestHistoryCapacity), OsuApiKey);
+
+            danmaku_filter.Scheduler = scheduler;
+            danmaku_filter.OsuApiKey = OsuApiKey;
+            danmaku_filter.EnableInsoMirrorLink = bool.Parse(EnableInsoMirrorLink);
+
+            osu_filter.Scheduler = scheduler;
+        }
+
+        public void onConfigurationLoad()
+        {
+
+        }
+
+        public void onConfigurationSave()
+        {
+
+        }
+
+        public void onConfigurationReload()
+        {
+            InitPlugin();
         }
     }
 }

--- a/BeatmapSuggest/BeatmapSuggestPlugin.cs
+++ b/BeatmapSuggest/BeatmapSuggestPlugin.cs
@@ -7,23 +7,35 @@ using System.Threading.Tasks;
 using Sync.Plugins;
 using Sync;
 using Sync.Command;
+using Sync.Tools;
 
 namespace BeatmapSuggest
 {
     [SyncPluginID("916fe745-7a33-4c20-b985-58c4810e261e", "2.15.0")]
     public class BeatmapSuggestPlugin : Plugin
     {
-        private Danmaku.BeatmapSuggestFilter filter = new Danmaku.BeatmapSuggestFilter();
+        private Danmaku.BeatmapSuggestFilter filter;
+
+        private PluginConfigurationManager config_manager;
 
         public BeatmapSuggestPlugin() : base("Beatmap Suggest Command", "Dark Projector")
         {
+            filter = new Danmaku.BeatmapSuggestFilter();
+
+            base.EventBus.BindEvent<PluginEvents.InitFilterEvent>(manager => manager.Filters.AddFilter(this.filter));
+            base.EventBus.BindEvent<PluginEvents.LoadCompleteEvent>(host => this.filter.SetFilterManager(host.Host.Messages));
+            Sync.Tools.IO.CurrentIO.WriteColor(Name + " By " + Author, ConsoleColor.DarkCyan);
+
+            config_manager = new PluginConfigurationManager(this);
+            config_manager.AddItem(filter);
         }
 
         public override void OnEnable()
         {
-            Sync.Tools.IO.CurrentIO.WriteColor(Name + " By " + Author, ConsoleColor.DarkCyan);
-            base.EventBus.BindEvent<PluginEvents.InitFilterEvent>(manager => manager.Filters.AddFilter(this.filter));
-            base.EventBus.BindEvent<PluginEvents.LoadCompleteEvent>(host => this.filter.SetFilterManager(host.Host.Messages));
+            if (string.IsNullOrWhiteSpace(filter.OsuApiKey))
+            {
+                IO.CurrentIO.WriteColor("[BeatmapSuggestPlugin]没有ApiKey,请用户自己提供ApiKey以便使用谱面推荐功能.ApiKey申请地址:https://osu.ppy.sh/p/api", ConsoleColor.Red);
+            }
         }
     }
 }

--- a/BeatmapSuggest/Danmaku/BeatmapSuggestFilter.cs
+++ b/BeatmapSuggest/Danmaku/BeatmapSuggestFilter.cs
@@ -16,13 +16,14 @@ using static BeatmapSuggest.DefaultLanguage;
 
 namespace BeatmapSuggest.Danmaku
 {
-    class BeatmapSuggestFilter : IFilter, ISourceDanmaku
+    class BeatmapSuggestFilter : IFilter, ISourceDanmaku,IConfigurable
     {
         private MessageDispatcher msgManager = null;
 
         private const string suggestCommand = "?suggest";
 
-        public ConfigurationElement EnableInsoMirrorLink { get; set; } = "0";
+        public ConfigurationElement EnableInsoMirrorLink { get; set; } = "False";
+        public ConfigurationElement OsuApiKey { get; set; } = string.Empty;
 
         const int timeout = 6000;//ms
 
@@ -67,6 +68,12 @@ namespace BeatmapSuggest.Danmaku
 
         private async void SendSuggestMessage(int id, string userName, bool isSetId = true)
         {
+            //check if users provide their api key.
+            if (String.IsNullOrWhiteSpace(OsuApiKey))
+            {
+                return;
+            }
+
             string[] beatmapInfo = null;
             try
             {
@@ -92,7 +99,7 @@ namespace BeatmapSuggest.Danmaku
             var task = new Task<string[]>(() =>
             {
                 string uri = @"https://osu.ppy.sh/api/get_beatmaps?" +
-                $@"k=b9f8ca3fc035078a5b111380bc21cd0b8e79d7b5&{(isSetId ? "s" : "b")}={id}&limit=1";
+                $@"k={OsuApiKey}&{(isSetId ? "s" : "b")}={id}&limit=1";
 
                 HttpWebRequest request = HttpWebRequest.Create(uri) as HttpWebRequest;
                 request.Method = "GET";
@@ -159,7 +166,7 @@ namespace BeatmapSuggest.Danmaku
 
         private string GetMirrorDownloadLink(int beatmapSetId)
         {
-            if (((string)EnableInsoMirrorLink).Trim() != "1")
+            if ((((string)EnableInsoMirrorLink).Trim() != "1")||(!bool.Parse(EnableInsoMirrorLink)))
             {
                 // Defualt
                 return $"http://osu.uu.gl/s/{beatmapSetId}";
@@ -179,6 +186,21 @@ namespace BeatmapSuggest.Danmaku
         public void Dispose()
         {
             //nothing to do
+        }
+
+        public void onConfigurationLoad()
+        {
+            
+        }
+
+        public void onConfigurationSave()
+        {
+            
+        }
+
+        public void onConfigurationReload()
+        {
+            
         }
     }
 }

--- a/BeatmapSuggest/Danmaku/BeatmapSuggestFilter.cs
+++ b/BeatmapSuggest/Danmaku/BeatmapSuggestFilter.cs
@@ -82,7 +82,7 @@ namespace BeatmapSuggest.Danmaku
                 beatmapInfo = await GetBeatmapInfo(id,isSetId);
 
                 if (beatmapInfo == null)
-                    throw new Exception(string.Format(LANG_GET_BEATMAP_FAILED,id,"信息不完整"));
+                    throw new Exception(string.Format(LANG_GET_BEATMAP_FAILED,id, LANG_ERROR_INFO_IMCOMPLETE));
             }
             catch (Exception e)
             {

--- a/BeatmapSuggest/Danmaku/BeatmapSuggestFilter.cs
+++ b/BeatmapSuggest/Danmaku/BeatmapSuggestFilter.cs
@@ -16,17 +16,19 @@ using static BeatmapSuggest.DefaultLanguage;
 
 namespace BeatmapSuggest.Danmaku
 {
-    class BeatmapSuggestFilter : IFilter, ISourceDanmaku,IConfigurable
+    class BeatmapSuggestFilter : IFilter, ISourceDanmaku
     {
         private MessageDispatcher msgManager = null;
 
         private const string suggestCommand = "?suggest";
 
-        public ConfigurationElement EnableInsoMirrorLink { get; set; } = "False";
-        public ConfigurationElement OsuApiKey { get; set; } = string.Empty;
+        internal BeatmapDownloadScheduler Scheduler { get; set; }
+
+        internal bool EnableInsoMirrorLink { get; set; }
+        internal string OsuApiKey { get; set; }
 
         const int timeout = 6000;//ms
-
+        
         public void onMsg(ref IMessageBase msg)
         {
             string message = msg.Message.RawText;
@@ -87,6 +89,8 @@ namespace BeatmapSuggest.Danmaku
                 IO.CurrentIO.WriteColor(string.Format(LANG_GET_BEATMAP_FAILED, id, e.Message),ConsoleColor.Red);
                 return;
             }
+
+            Scheduler.Push(id, isSetId, $"{beatmapInfo[3]} - {beatmapInfo[2]}");
 
             string message = string.Format(LANG_SUGGEST_MEG,userName,GetLink(id,isSetId),$"{beatmapInfo[3]} - {beatmapInfo[2]}[{beatmapInfo[4]}]",GetDownloadLink(int.Parse(beatmapInfo[1])),GetMirrorDownloadLink(int.Parse(beatmapInfo[0])));
             msgManager.RaiseMessage<ISourceClient>(new IRCMessage(string.Empty, message));
@@ -166,7 +170,7 @@ namespace BeatmapSuggest.Danmaku
 
         private string GetMirrorDownloadLink(int beatmapSetId)
         {
-            if ((((string)EnableInsoMirrorLink).Trim() != "1")||(!bool.Parse(EnableInsoMirrorLink)))
+            if (EnableInsoMirrorLink)
             {
                 // Defualt
                 return $"http://osu.uu.gl/s/{beatmapSetId}";
@@ -186,21 +190,6 @@ namespace BeatmapSuggest.Danmaku
         public void Dispose()
         {
             //nothing to do
-        }
-
-        public void onConfigurationLoad()
-        {
-            
-        }
-
-        public void onConfigurationSave()
-        {
-            
-        }
-
-        public void onConfigurationReload()
-        {
-            
         }
     }
 }

--- a/BeatmapSuggest/DefaultLanguage.cs
+++ b/BeatmapSuggest/DefaultLanguage.cs
@@ -10,12 +10,19 @@ namespace BeatmapSuggest
     public class DefaultLanguage:I18nProvider
     {
         public static LanguageElement LANG_GET_BEATMAP_FAILED = "获取谱面{0}信息失败,原因:{1}";
-        public static LanguageElement LANG_SUGGEST_MEG = "{0} want you to play the beatmap [{1} {2}] || [{3} dl] || [{4} mirror]";
+        public static LanguageElement LANG_SUGGEST_MEG = "{0} want you to play the beatmap [{1} {2}] || [{3} dl] || [{4} mirror] or type\"?dl\"/\"?dl all\"";
         public static LanguageElement LANG_NOT_FOUND_ERR = "找不到匹配的内容或者id并不是有效的beatmapSetId";
         public static LanguageElement LANG_UNKNOWN_TITLE = "<unk title>";
         public static LanguageElement LANG_GET_BEATMAP_TIME_OUT = "获取谱面{0}信息超时,TaskStatus{1}";
 
         public static LanguageElement LANG_INVAILD_ID = "无效的id值 {0}";
         public static LanguageElement LANG_UNKOWN_PARAM = "未知参数 {0}";
+
+        public static LanguageElement LANG_ERROR_INFO_IMCOMPLETE = "信息不完整";
+        public static LanguageElement LANG_NO_API_KEY_NOFITY = "没有ApiKey,请用户自己提供ApiKey以便使用谱面推荐功能.ApiKey申请地址:https://osu.ppy.sh/p/api";
+        public static LanguageElement LANG_START_DOWNLOAD = "开始下载谱面{0}";
+        public static LanguageElement LANG_FINISH_DOWNLOAD = "下载谱面{0}完成";
+        public static LanguageElement LANG_FAILED_DOWNLOAD= "下载谱面{0}出错,原因{1}";
+        public static LanguageElement LANG_DOWNLOAD_TASK_COUNT = "开始下载共{0}张谱面.";
     }
 }

--- a/BeatmapSuggest/Osu/BeatmapSuggestDownloadFilter.cs
+++ b/BeatmapSuggest/Osu/BeatmapSuggestDownloadFilter.cs
@@ -1,0 +1,37 @@
+﻿using Sync.MessageFilter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatmapSuggest.Osu
+{
+    class BeatmapSuggestDownloadFilter : IFilter, ISourceClient
+    {
+        private const string DownloadCommand = "?dl";
+
+        internal BeatmapDownloadScheduler Scheduler { get; set; }
+
+        public void onMsg(ref IMessageBase msg)
+        {
+            if ((!msg.Message.RawText.StartsWith(DownloadCommand))||Scheduler == null)
+                return;
+
+            string param = msg.Message.RawText.Replace(DownloadCommand, string.Empty).Trim();
+
+            switch (param)
+            {
+                case "":
+                case "last":
+                    Scheduler.DownloadLastSuggest();
+                    break;
+                case "all":
+                    Scheduler.DownloadAll();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/BeatmapSuggest/Osu/BeatmapSuggestDownloadFilter.cs
+++ b/BeatmapSuggest/Osu/BeatmapSuggestDownloadFilter.cs
@@ -18,6 +18,8 @@ namespace BeatmapSuggest.Osu
             if ((!msg.Message.RawText.StartsWith(DownloadCommand))||Scheduler == null)
                 return;
 
+            msg.Cancel = true;
+
             string param = msg.Message.RawText.Replace(DownloadCommand, string.Empty).Trim();
 
             switch (param)


### PR DESCRIPTION
* 钦定NowPlaying可以自动获取屙屎文件路径
* 删除BeatmapSuggest代码原有api_key,使用谱面介绍文件前得先提供自己申请得到的api_key
* BeatmapSuggest支持后台下载推荐的谱面,在irc频道可以用?dl后台下载最近推荐的谱面,或者"?dl all"下载全推荐的谱面
* 修复BeatmapSuggest一些问题,支持I18n等
* BeatmapSuggest推荐命令可简写(如直播间发送"s/33809")
